### PR TITLE
v1.1.0rc11

### DIFF
--- a/ElectricSidecar/ElectricSidecar.xcodeproj/project.pbxproj
+++ b/ElectricSidecar/ElectricSidecar.xcodeproj/project.pbxproj
@@ -58,6 +58,10 @@
 		661DF6DC29B5704500F2C9A3 /* UITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661DF6D829B5704100F2C9A3 /* UITestCase.swift */; };
 		664884A929B5D15100F787B6 /* VehicleChargeWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66108D64296B56AF00791A7A /* VehicleChargeWidget.swift */; };
 		664884AA29B5D15B00F787B6 /* VehicleChargeTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66108D88296B57CB00791A7A /* VehicleChargeTimelineProvider.swift */; };
+		664884AD29B6683000F787B6 /* SettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664884AC29B6683000F787B6 /* SettingsPage.swift */; };
+		664884AE29B6683000F787B6 /* SettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664884AC29B6683000F787B6 /* SettingsPage.swift */; };
+		664884B129B66A0400F787B6 /* ChargeSettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664884B029B66A0400F787B6 /* ChargeSettingsPage.swift */; };
+		664884B229B66A0400F787B6 /* ChargeSettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 664884B029B66A0400F787B6 /* ChargeSettingsPage.swift */; };
 		664ACF68298E290A00E76985 /* WatchConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665C3F25298E0985002BAD30 /* WatchConnectivityObserver.swift */; };
 		66513E45298F58E90094581B /* AuthModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66513E44298F58E90094581B /* AuthModel.swift */; };
 		66513E46298F58E90094581B /* AuthModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66513E44298F58E90094581B /* AuthModel.swift */; };
@@ -110,6 +114,8 @@
 		665C3F2D298E0D73002BAD30 /* AppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66108D78296B572F00791A7A /* AppGroup.swift */; };
 		665EDD5A297289C40012CD3A /* RefreshStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665EDD59297289C40012CD3A /* RefreshStatusView.swift */; };
 		665EDD5C2972973F0012CD3A /* ElectricSidecarWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 665EDD5B2972973F0012CD3A /* ElectricSidecarWidgets.swift */; };
+		666164CE29B68521004DAF95 /* ReloadingWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666164CD29B68521004DAF95 /* ReloadingWidgets.swift */; };
+		666164CF29B68521004DAF95 /* ReloadingWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666164CD29B68521004DAF95 /* ReloadingWidgets.swift */; };
 		66743FD1298E2DF2002A799F /* Refreshable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661C3F5029726E9100A4CC90 /* Refreshable.swift */; };
 		66743FD2298E2DF2002A799F /* Vehicle+Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 661C3F4929725D0900A4CC90 /* Vehicle+Status.swift */; };
 		66743FD3298E2DF2002A799F /* Vehicle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CA7DA0296FE95D00090ADD /* Vehicle.swift */; };
@@ -410,6 +416,8 @@
 		661D5B4429B3B23500E2F222 /* ComplicationDimensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationDimensions.swift; sourceTree = "<group>"; };
 		661DF6D629B56FA900F2C9A3 /* Base.lproj */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Base.lproj; path = PhoneUITests/Base.lproj; sourceTree = SOURCE_ROOT; };
 		661DF6D829B5704100F2C9A3 /* UITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestCase.swift; sourceTree = "<group>"; };
+		664884AC29B6683000F787B6 /* SettingsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPage.swift; sourceTree = "<group>"; };
+		664884B029B66A0400F787B6 /* ChargeSettingsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChargeSettingsPage.swift; sourceTree = "<group>"; };
 		66513E44298F58E90094581B /* AuthModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthModel.swift; sourceTree = "<group>"; };
 		6651491129B58654003D0401 /* MockData */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MockData; sourceTree = "<group>"; };
 		6651491629B59E4C003D0401 /* Intents.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = Intents.intentdefinition; sourceTree = "<group>"; };
@@ -428,6 +436,7 @@
 		665C3F25298E0985002BAD30 /* WatchConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityObserver.swift; sourceTree = "<group>"; };
 		665EDD59297289C40012CD3A /* RefreshStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshStatusView.swift; sourceTree = "<group>"; };
 		665EDD5B2972973F0012CD3A /* ElectricSidecarWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElectricSidecarWidgets.swift; sourceTree = "<group>"; };
+		666164CD29B68521004DAF95 /* ReloadingWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReloadingWidgets.swift; sourceTree = "<group>"; };
 		66743FFA298E32CD002A799F /* PhoneWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PhoneWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		66743FFB298E32CD002A799F /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		66743FFD298E32CD002A799F /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
@@ -675,6 +684,7 @@
 				661C3F4C29725D2800A4CC90 /* UIModel */,
 				660E7607297E593A00EEF434 /* Views */,
 				665C3F24298E0973002BAD30 /* WatchConnectivity */,
+				666164CC29B68509004DAF95 /* Widgets */,
 				66108D77296B572F00791A7A /* ModelStore.swift */,
 				6618E351296FDE5900F370BB /* CodableCacheCoordinator.swift */,
 				6611979F29750EE800D92637 /* Shared.xcassets */,
@@ -719,6 +729,7 @@
 			children = (
 				66108DAB296B58F700791A7A /* GarageView.swift */,
 				669BFB5B296BF933004621D9 /* Vehicle */,
+				664884AB29B6681B00F787B6 /* Settings */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -743,6 +754,23 @@
 				661D5B4429B3B23500E2F222 /* ComplicationDimensions.swift */,
 			);
 			path = DeviceTraits;
+			sourceTree = "<group>";
+		};
+		664884AB29B6681B00F787B6 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				664884AC29B6683000F787B6 /* SettingsPage.swift */,
+				664884AF29B669F600F787B6 /* Pages */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		664884AF29B669F600F787B6 /* Pages */ = {
+			isa = PBXGroup;
+			children = (
+				664884B029B66A0400F787B6 /* ChargeSettingsPage.swift */,
+			);
+			path = Pages;
 			sourceTree = "<group>";
 		};
 		66513E43298F58DD0094581B /* Authentication */ = {
@@ -843,6 +871,14 @@
 				66108D64296B56AF00791A7A /* VehicleChargeWidget.swift */,
 			);
 			path = VehicleCharge;
+			sourceTree = "<group>";
+		};
+		666164CC29B68509004DAF95 /* Widgets */ = {
+			isa = PBXGroup;
+			children = (
+				666164CD29B68521004DAF95 /* ReloadingWidgets.swift */,
+			);
+			path = Widgets;
 			sourceTree = "<group>";
 		};
 		66744033298E3826002A799F /* LiveActivities */ = {
@@ -1309,8 +1345,8 @@
 			targets = (
 				668B86512986F2A600C60DE8 /* ElectricSidecar */,
 				6651491E29B59ED6003D0401 /* ElectricSidecarIntents */,
-				66743FF9298E32CD002A799F /* PhoneWidgets */,
 				66108D25296B569000791A7A /* Watch */,
+				66743FF9298E32CD002A799F /* PhoneWidgets */,
 				66108D5C296B56AF00791A7A /* WatchWidgets */,
 				66108D37296B569100791A7A /* UnitTests */,
 				66108D41296B569100791A7A /* WatchUITests */,
@@ -1443,6 +1479,7 @@
 				661D5B4929B3B36600E2F222 /* ComplicationDimensions.swift in Sources */,
 				664884AA29B5D15B00F787B6 /* VehicleChargeTimelineProvider.swift in Sources */,
 				668EB95C29792E8100304EA5 /* VehiclePhotosPage.swift in Sources */,
+				666164CF29B68521004DAF95 /* ReloadingWidgets.swift in Sources */,
 				66108DA6296B58EE00791A7A /* Vehicle+SwiftUI.swift in Sources */,
 				66108DB0296B58F700791A7A /* VehicleView.swift in Sources */,
 				661C3F4E2972641500A4CC90 /* UIModel.swift in Sources */,
@@ -1456,6 +1493,7 @@
 				66108D87296B579800791A7A /* TitledTabViews.swift in Sources */,
 				661C3F4A29725D0900A4CC90 /* Vehicle+Status.swift in Sources */,
 				66108DB1296B58F700791A7A /* GarageView.swift in Sources */,
+				664884B229B66A0400F787B6 /* ChargeSettingsPage.swift in Sources */,
 				66108DA7296B58EE00791A7A /* Vehicle+Helpers.swift in Sources */,
 				665EDD5A297289C40012CD3A /* RefreshStatusView.swift in Sources */,
 				668B8609297F951C00C60DE8 /* Vehicle+Doors.swift in Sources */,
@@ -1464,6 +1502,7 @@
 				66108D79296B572F00791A7A /* ModelStore.swift in Sources */,
 				661C3F572972770800A4CC90 /* Vehicle+Position.swift in Sources */,
 				668EB9592979119B00304EA5 /* Logging.swift in Sources */,
+				664884AE29B6683000F787B6 /* SettingsPage.swift in Sources */,
 				668B861829865BE900C60DE8 /* RadialProgressView.swift in Sources */,
 				6651ED042986FB71001337A3 /* BatteryStyle.swift in Sources */,
 				66513E47298F58E90094581B /* AuthModel.swift in Sources */,
@@ -1693,6 +1732,7 @@
 				66743FD8298E2DF7002A799F /* ModelStore.swift in Sources */,
 				661D5B4829B3B36500E2F222 /* ComplicationDimensions.swift in Sources */,
 				665C3F26298E0985002BAD30 /* WatchConnectivityObserver.swift in Sources */,
+				666164CE29B68521004DAF95 /* ReloadingWidgets.swift in Sources */,
 				66743FDB298E2E07002A799F /* Emobility+Helpers.swift in Sources */,
 				668B86592986F2A700C60DE8 /* LoginViewController.swift in Sources */,
 				66743FD5298E2DF2002A799F /* Vehicle+Doors.swift in Sources */,
@@ -1710,10 +1750,12 @@
 				66743FD7298E2DF2002A799F /* Vehicle+Position.swift in Sources */,
 				66743FEF298E2F4B002A799F /* LogsView.swift in Sources */,
 				669902D329B45D1B001004AC /* RangeView.swift in Sources */,
+				664884AD29B6683000F787B6 /* SettingsPage.swift in Sources */,
 				665C3F2D298E0D73002BAD30 /* AppGroup.swift in Sources */,
 				66743FE6298E2F27002A799F /* VehicleLocationPage.swift in Sources */,
 				66743FDC298E2E07002A799F /* Vehicle+Helpers.swift in Sources */,
 				66743FE7298E2F27002A799F /* VehiclePhotosPage.swift in Sources */,
+				664884B129B66A0400F787B6 /* ChargeSettingsPage.swift in Sources */,
 				66744035298E3BFC002A799F /* ChargingActivityAttributes.swift in Sources */,
 				66743FF3298E2F96002A799F /* BatteryStyle.swift in Sources */,
 				66513E45298F58E90094581B /* AuthModel.swift in Sources */,

--- a/ElectricSidecar/ElectricSidecar.xcodeproj/project.pbxproj
+++ b/ElectricSidecar/ElectricSidecar.xcodeproj/project.pbxproj
@@ -2515,7 +2515,7 @@
 				DEVELOPMENT_TEAM = ZGWD8QJUPK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Phone/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = ElectricSidecar;
+				INFOPLIST_KEY_CFBundleDisplayName = Sidecar;
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -2548,7 +2548,7 @@
 				EXCLUDED_SOURCE_FILE_NAMES = MockData;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Phone/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = ElectricSidecar;
+				INFOPLIST_KEY_CFBundleDisplayName = Sidecar;
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;

--- a/ElectricSidecar/ElectricSidecar.xcodeproj/xcshareddata/xcschemes/Watch.xcscheme
+++ b/ElectricSidecar/ElectricSidecar.xcodeproj/xcshareddata/xcschemes/Watch.xcscheme
@@ -93,7 +93,7 @@
          <EnvironmentVariable
             key = "SIMULATED_GARAGE"
             value = "MultiCar"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
    </LaunchAction>

--- a/ElectricSidecar/Phone/LoginViewController.swift
+++ b/ElectricSidecar/Phone/LoginViewController.swift
@@ -1,3 +1,4 @@
+import PorscheConnect
 import UIKit
 import SwiftUI
 import WatchConnectivity
@@ -19,6 +20,7 @@ protocol LoginViewControllerDelegate: AnyObject {
 
 final class LoginViewController: UIViewController {
   weak var delegate: LoginViewControllerDelegate?
+  var error: Error?
 
   init(email: String, password: String) {
     self.model = ViewModel(email: email, password: password)
@@ -44,7 +46,7 @@ final class LoginViewController: UIViewController {
 
     view.backgroundColor = .systemBackground
 
-    let loginView = LoginView(model: model, didLogin: { [weak self] in
+    let loginView = LoginView(model: model, error: error, didLogin: { [weak self] in
       guard let self else {
         return
       }
@@ -106,7 +108,7 @@ struct LoginTextFieldStyle: TextFieldStyle {
 }
 
 struct LoginButtonStyle: ButtonStyle {
-  @Environment(\.isEnabled) private var isEnabled
+  @SwiftUI.Environment(\.isEnabled) private var isEnabled
   func makeBody(configuration: Self.Configuration) -> some View {
     configuration.label
       .padding()
@@ -118,6 +120,7 @@ struct LoginButtonStyle: ButtonStyle {
 
 struct LoginView: View {
   @ObservedObject fileprivate var model: ViewModel
+  var error: Error?
   let didLogin: () -> Void
 
   var body: some View {
@@ -135,6 +138,18 @@ struct LoginView: View {
         .frame(maxWidth: .infinity)
         .buttonStyle(LoginButtonStyle())
       Spacer(minLength: 32)
+
+      if let error {
+        switch error {
+        case PorscheConnectError.AuthFailure:
+          Text("Authentication failure. Check your credentials and try again.")
+            .foregroundColor(.red)
+        default:
+          Text(error.localizedDescription)
+        }
+        Spacer(minLength: 32)
+      }
+
       Text("If you already logged in on your watch, open the ElectricSidecar app on your watch to use your existing login credentials.")
 
       if model.watchIsReachable {

--- a/ElectricSidecar/Shared/Authentication/AuthModel.swift
+++ b/ElectricSidecar/Shared/Authentication/AuthModel.swift
@@ -19,21 +19,35 @@ protocol AuthModeling: AnyObject {
 #endif
 }
 
+struct ChargeWidgetPreferences: Codable {
+  enum CircularLayout: Codable, CaseIterable {
+    case chargeStateInCenter
+    case percentInCenter
+  }
+  var circularLayout: CircularLayout
+}
+
 struct Preferences: Codable, RawRepresentable {
   var primaryVIN: String = ""
+  var chargeWidget: ChargeWidgetPreferences = ChargeWidgetPreferences(
+    circularLayout: .chargeStateInCenter
+  )
 
   enum CodingKeys: String, CodingKey {
     case primaryVIN
+    case chargeWidget
   }
 
   init(from decoder: Decoder) throws {
     let group = try decoder.container(keyedBy: CodingKeys.self)
     primaryVIN = try group.decode(String.self, forKey: .primaryVIN)
+    chargeWidget = try group.decode(ChargeWidgetPreferences.self, forKey: .chargeWidget)
   }
 
   func encode(to encoder: Encoder) throws {
     var group = encoder.container(keyedBy: CodingKeys.self)
     try group.encode(primaryVIN, forKey: .primaryVIN)
+    try group.encode(chargeWidget, forKey: .chargeWidget)
   }
 
   init() {

--- a/ElectricSidecar/Shared/Authentication/AuthModel.swift
+++ b/ElectricSidecar/Shared/Authentication/AuthModel.swift
@@ -8,6 +8,7 @@ protocol AuthModeling: AnyObject {
   var email: String { get set }
   var password: String { get set }
   var store: ModelStore? { get }
+  func authenticationFailed()
 
   var preferences: Preferences { get set }
 
@@ -84,6 +85,9 @@ final class AuthModel: AuthModeling {
     return _store
   }
   private var _store: ModelStore?
+  func authenticationFailed() {
+    _store = nil
+  }
 
   init() {
     NotificationCenter.default.addObserver(
@@ -153,6 +157,10 @@ final class FakeAuthModel: AuthModeling {
     return _store
   }
   private var _store: ModelStore?
+
+  func authenticationFailed() {
+    _store = nil
+  }
 }
 
 let AUTH_MODEL: AuthModeling = {
@@ -169,6 +177,8 @@ let AUTH_MODEL: AuthModeling = {
     model.email = "test@test.com"
     model.password = "test"
     model.simulatedGarage = simulatedGarage
+  } else if Bundle.main.bundleURL.pathExtension != "appex" {
+    model.simulatedGarage = ""
   }
 #endif
   return model

--- a/ElectricSidecar/Shared/DeviceTraits/ComplicationDimensions.swift
+++ b/ElectricSidecar/Shared/DeviceTraits/ComplicationDimensions.swift
@@ -55,11 +55,7 @@ public func circularComplicationLineWidth() -> Double {
   switch formFactor() {
   case .phone:
     return 6
-  case .watch45mm, .ultra49mm:
-    return 5
-  case .watch44mm:
-    return 5
-  case .watch41mm:
+  case .watch45mm, .ultra49mm, .watch44mm, .watch41mm:
     return 5
   case .watch40mm:
     return 4

--- a/ElectricSidecar/Shared/Views/ChargeView.swift
+++ b/ElectricSidecar/Shared/Views/ChargeView.swift
@@ -113,11 +113,11 @@ struct ChargeView: View {
     case .percentInCenter:
       switch formFactor() {
       case .phone:
-        return is100Percent ? 22 : 28
+        return 22
       case .ultra49mm, .watch45mm:
-        return is100Percent ? 20 : 24
+        return 20
       case .watch44mm, .watch41mm, .watch40mm:
-        return is100Percent ? 18 : 22
+        return 18
       }
     }
   }
@@ -148,22 +148,7 @@ struct ChargeView: View {
   }
 
   var primaryOffset: CGSize {
-    switch layout {
-    case .chargeStateInCenter:
-      switch formFactor() {
-      case .watch44mm:
-        return CGSize(width: 0, height: -3)
-      default:
-        return CGSize(width: 0, height: -2)
-      }
-    case .percentInCenter:
-      switch formFactor() {
-      case .phone:
-        return CGSize(width: 0, height: -1)
-      default:
-        return CGSize(width: 0, height: is100Percent ? -1 : -2)
-      }
-    }
+    return CGSize(width: 0, height: -2)
   }
 
   var secondaryOffset: CGSize {

--- a/ElectricSidecar/Shared/Views/ChargeView.swift
+++ b/ElectricSidecar/Shared/Views/ChargeView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ChargeView: View {
   var batteryLevel: Double?
   var isCharging: Bool?
+  var layout: ChargeWidgetPreferences.CircularLayout = .chargeStateInCenter
 
   var allowsAnimation = false
   @State var pulseIsOn = true
@@ -35,16 +36,45 @@ struct ChargeView: View {
         }
         .widgetAccentable(true)
 
-        VStack(spacing: 0) {
-          Image(isCharging == true ? "taycan.charge" : "taycan")
-            .font(.system(size: iconFontSize))
-            .padding(.top, iconOffset)
-            .unredacted()
-          Text(batteryLevelFormatted)
-            .fontDesign(.rounded)
-            .font(.system(size: labelFontSize))
-            .padding(.top, iconPadding)
-            .unredacted()
+        switch layout {
+        case .chargeStateInCenter:
+          VStack(spacing: 0) {
+            Spacer().frame(maxHeight: .infinity)
+            Image(isCharging == true ? "taycan.charge" : "taycan")
+              .font(.system(size: primaryFontSize))
+              .fontWeight(.medium)
+              .offset(primaryOffset)
+              .unredacted()
+            Spacer().frame(maxHeight: .infinity)
+          }
+          VStack(spacing: 0) {
+            Spacer().frame(maxHeight: .infinity)
+            Text(batteryLevelFormatted)
+              .fontDesign(.rounded)
+              .fontWeight(.medium)
+              .font(.system(size: secondaryFontSize))
+              .offset(secondaryOffset)
+              .unredacted()
+          }
+        case .percentInCenter:
+          VStack(spacing: 0) {
+            Spacer().frame(maxHeight: .infinity)
+            Text(batteryLevelFormatted)
+              .font(.system(size: primaryFontSize))
+              .fontDesign(.rounded)
+              .bold()
+              .offset(primaryOffset)
+              .unredacted()
+            Spacer().frame(maxHeight: .infinity)
+          }
+          VStack(spacing: 0) {
+            Spacer().frame(maxHeight: .infinity)
+            Image(isCharging == true ? "taycan.charge" : "taycan")
+              .font(.system(size: secondaryFontSize))
+              .fontWeight(.medium)
+              .offset(secondaryOffset)
+              .unredacted()
+          }
         }
       } else {
         RadialProgressView(
@@ -55,70 +85,93 @@ struct ChargeView: View {
         )
         Image("taycan")
           .foregroundColor(.gray)
-          .font(.system(size: iconFontSize))
-          .padding(.top, -5)
+          .font(.system(size: iconInCenterFontSize))
+          .fontWeight(.medium)
+          .offset(primaryOffset)
           .unredacted()
       }
     }
   }
 
-  var iconFontSize: Double {
+  private var iconInCenterFontSize: Double {
     switch formFactor() {
     case .phone:
       return 26
-    case .watch45mm, .ultra49mm:
+    case .ultra49mm, .watch45mm:
       return 24
     case .watch44mm:
       return 22
-    case .watch41mm:
-      return 20
-    case .watch40mm:
+    case .watch41mm, .watch40mm:
       return 20
     }
   }
 
-  var iconOffset: Double {
-    switch formFactor() {
-    case .phone:
-      return 12
-    case .watch45mm, .ultra49mm:
-      return 9
-    case .watch44mm:
-      return 9
-    case .watch41mm:
-      return 9
-    case .watch40mm:
-      return 7
+  var primaryFontSize: Double {
+    switch layout {
+    case .chargeStateInCenter:
+      return iconInCenterFontSize
+    case .percentInCenter:
+      switch formFactor() {
+      case .phone:
+        return is100Percent ? 22 : 28
+      case .ultra49mm, .watch45mm:
+        return is100Percent ? 20 : 24
+      case .watch44mm, .watch41mm, .watch40mm:
+        return is100Percent ? 18 : 22
+      }
     }
   }
 
-  var iconPadding: Double {
-    switch formFactor() {
-    case .phone:
-      return 0
-    case .watch45mm, .ultra49mm:
-      return -2
-    case .watch44mm:
-      return -2
-    case .watch41mm:
-      return -2
-    case .watch40mm:
-      return -3
+  var secondaryFontSize: Double {
+    switch layout {
+    case .chargeStateInCenter:
+      switch formFactor() {
+      case .phone:
+        return 14
+      case .ultra49mm, .watch45mm, .watch44mm:
+        return 13
+      case .watch41mm:
+        return 12
+      case .watch40mm:
+        return 11
+      }
+    case .percentInCenter:
+      switch formFactor() {
+      case .phone:
+        return 16
+      case .ultra49mm, .watch45mm, .watch44mm, .watch41mm:
+        return 14
+      case .watch40mm:
+        return 12
+      }
     }
   }
 
-  var labelFontSize: Double {
-    switch formFactor() {
-    case .phone:
-      return 14
-    case .watch45mm, .ultra49mm:
-      return 13
-    case .watch44mm:
-      return 13
-    case .watch41mm:
-      return 12
-    case .watch40mm:
-      return 13
+  var primaryOffset: CGSize {
+    switch layout {
+    case .chargeStateInCenter:
+      switch formFactor() {
+      case .watch44mm:
+        return CGSize(width: 0, height: -3)
+      default:
+        return CGSize(width: 0, height: -2)
+      }
+    case .percentInCenter:
+      switch formFactor() {
+      case .phone:
+        return CGSize(width: 0, height: -1)
+      default:
+        return CGSize(width: 0, height: is100Percent ? -1 : -2)
+      }
+    }
+  }
+
+  var secondaryOffset: CGSize {
+    switch layout {
+    case .chargeStateInCenter:
+      return CGSize(width: 0, height: formFactor() == .phone ? -1 : -0.5)
+    case .percentInCenter:
+      return CGSize(width: 0, height: -1)
     }
   }
 
@@ -129,7 +182,7 @@ struct ChargeView: View {
   var fillRatio: Double {
     switch formFactor() {
     case .phone:
-      if batteryLevel == 100 {
+      if layout == .chargeStateInCenter && is100Percent {
         // Give a bit of breathing room around the text
         return 0.67
       }
@@ -137,7 +190,7 @@ struct ChargeView: View {
     case .watch45mm, .ultra49mm:
       return 0.7
     case .watch44mm:
-      if batteryLevel == 100 {
+      if layout == .chargeStateInCenter && is100Percent {
         // Give a bit of breathing room around the text
         return 0.67
       }
@@ -149,41 +202,101 @@ struct ChargeView: View {
     }
   }
 
+  var is100Percent: Bool {
+    guard let batteryLevel else {
+      return false
+    }
+    return String(format: "%.0f%", batteryLevel) == "100"
+  }
+
   var batteryLevelFormatted: String? {
     guard let batteryLevel else {
       return nil
     }
-    return String(format: "%.0f%%", batteryLevel)
+    switch layout {
+    case .chargeStateInCenter:
+      return String(format: "%.0f%%", batteryLevel)
+    case .percentInCenter:
+      return String(format: "%.0f%", batteryLevel)
+    }
   }
 }
 
 struct ChargeView_Previews: PreviewProvider {
   static var previews: some View {
-    ZStack {
-      Color.red  // For debugging layout.
+    VStack {
       HStack {
-        ChargeView(
-          batteryLevel: 50,
-          isCharging: true
-        )
+        ZStack {
+//          Color.red  // For debugging layout.
+          ChargeView(
+            batteryLevel: 50,
+            isCharging: false,
+            layout: .chargeStateInCenter
+          )
+        }
+        .frame(width: circularComplicationSize().width,
+               height: circularComplicationSize().height)
+        .cornerRadius(circularComplicationSize().width / 2)
+        ZStack {
+//          Color.red  // For debugging layout.
+          ChargeView(
+            batteryLevel: 100,
+            isCharging: true,
+            layout: .chargeStateInCenter
+          )
+        }
+        .frame(width: circularComplicationSize().width,
+               height: circularComplicationSize().height)
+        .cornerRadius(circularComplicationSize().width / 2)
+      }
+      HStack {
+        ZStack {
+//          Color.red  // For debugging layout.
+          ChargeView(
+            batteryLevel: 50,
+            isCharging: true,
+            layout: .percentInCenter
+          )
+        }
+        .frame(width: circularComplicationSize().width,
+               height: circularComplicationSize().height)
+        .cornerRadius(circularComplicationSize().width / 2)
+        ZStack {
+//          Color.red  // For debugging layout.
+          ChargeView(
+            batteryLevel: 100,
+            isCharging: false,
+            layout: .percentInCenter
+          )
+        }
+        .frame(width: circularComplicationSize().width,
+               height: circularComplicationSize().height)
+        .cornerRadius(circularComplicationSize().width / 2)
+      }
+      HStack {
+        ZStack {
+          //          Color.red  // For debugging layout.
+          ChargeView(
+            batteryLevel: nil,
+            isCharging: nil,
+            layout: .chargeStateInCenter
+          )
+        }
+        .frame(width: circularComplicationSize().width,
+               height: circularComplicationSize().height)
+        .cornerRadius(circularComplicationSize().width / 2)
+        ZStack {
+          //          Color.red  // For debugging layout.
+          ChargeView(
+            batteryLevel: nil,
+            isCharging: nil,
+            layout: .percentInCenter
+          )
+        }
+        .frame(width: circularComplicationSize().width,
+               height: circularComplicationSize().height)
+        .cornerRadius(circularComplicationSize().width / 2)
       }
     }
-    .frame(width: circularComplicationSize().width,
-           height: circularComplicationSize().height)
-    .cornerRadius(circularComplicationSize().width / 2)
-    .previewDisplayName("Valid")
-
-    ZStack {
-      HStack {
-        ChargeView(
-          batteryLevel: nil,
-          isCharging: nil
-        )
-      }
-    }
-    .frame(width: circularComplicationSize().width,
-           height: circularComplicationSize().height)
-    .cornerRadius(circularComplicationSize().width / 2)
-    .previewDisplayName("Nil state")
   }
 }

--- a/ElectricSidecar/Shared/Views/RangeView.swift
+++ b/ElectricSidecar/Shared/Views/RangeView.swift
@@ -29,19 +29,21 @@ struct RangeView: View {
       if let rangeRemaining {
         VStack(spacing: 0) {
           Text(String(format: "%.0f", rangeRemaining))
-            .font(.system(size: rangeFontSize))
+            .font(.system(size: primaryFontSize))
             .fontDesign(.rounded)
             .bold()
             .unredacted()
           Text(Locale.current.measurementSystem == .metric ? "km" : "mi")
-            .font(.system(size: labelFontSize))
+            .font(.system(size: secondaryFontSize))
+            .fontWeight(.medium)
             .padding(.top, labelTopPadding)
             .padding(.bottom, labelBottomPadding)
             .unredacted()
         }
       } else {
         Text(Locale.current.measurementSystem == .metric ? "km" : "mi")
-          .font(.system(size: labelFontSize))
+          .font(.system(size: secondaryFontSize))
+          .fontWeight(.medium)
           .padding(.top, labelTopPadding + 20)
           .padding(.bottom, labelBottomPadding)
           .foregroundColor(.gray)
@@ -50,31 +52,27 @@ struct RangeView: View {
     }
   }
 
-  var rangeFontSize: Double {
+  var primaryFontSize: Double {
     switch formFactor() {
     case .phone:
       return 22
-    case .watch45mm, .ultra49mm:
+    case .watch45mm, .ultra49mm, .watch44mm:
       return 20
-    case .watch44mm:
-      return 20
-    case .watch41mm:
-      return 18
-    case .watch40mm:
+    case .watch41mm, .watch40mm:
       return 18
     }
   }
 
-  var labelFontSize: Double {
+  var secondaryFontSize: Double {
     switch formFactor() {
     case .phone:
       return 16
     case .watch45mm, .ultra49mm:
-      return 14
+      return 14.5
     case .watch44mm:
-      return 14
+      return 13
     case .watch41mm:
-      return 12
+      return 12.5
     case .watch40mm:
       return 12
     }

--- a/ElectricSidecar/Shared/Widgets/ReloadingWidgets.swift
+++ b/ElectricSidecar/Shared/Widgets/ReloadingWidgets.swift
@@ -1,0 +1,7 @@
+import Foundation
+import WidgetKit
+
+func reloadAllTimelines() {
+  UserDefaults(suiteName: APP_GROUP_IDENTIFIER)!.synchronize()
+  WidgetCenter.shared.reloadAllTimelines()
+}

--- a/ElectricSidecar/UI/GarageView.swift
+++ b/ElectricSidecar/UI/GarageView.swift
@@ -12,10 +12,10 @@ struct GarageView: View {
   @State var isLogReadingEnabled: Bool = false
 
   var body: some View {
-    NavigationStack {
-      if let vehicles = store.vehicles {
-        TabView {
-          ForEach(vehicles) { vehicle in
+    if let vehicles = store.vehicles {
+      TabView {
+        ForEach(vehicles) { vehicle in
+          NavigationStack {
             VehicleView(
               vehicle: vehicle,
               hasManyVehicles: vehicles.count > 1,
@@ -48,35 +48,41 @@ struct GarageView: View {
               print("Unlock the car...")
             }
             .navigationTitle(vehicle.licensePlate ?? "\(vehicle.modelDescription) (\(vehicle.modelYear))")
+          }
 #if !os(watchOS)
+          .tabItem {
+            Label(vehicle.licensePlate ?? vehicle.modelDescription, image: "taycan")
+          }
+#endif
+        }
+        if isLogReadingEnabled {
+          LogsView()
+#if os(watchOS)
             .tabItem {
-              Label(vehicle.licensePlate ?? vehicle.modelDescription, image: "taycan")
+              Label("Debug logs", systemImage: "magnifyingglass")
+            }
+#else
+            .tabItem {
+              Label("Debug logs", systemImage: "rectangle.and.text.magnifyingglass")
             }
 #endif
-          }
-          if isLogReadingEnabled {
-            LogsView()
-#if os(watchOS)
-              .tabItem {
-                Label("Debug logs", systemImage: "magnifyingglass")
-              }
-#else
-              .tabItem {
-                Label("Debug logs", systemImage: "rectangle.and.text.magnifyingglass")
-              }
-#endif
-          }
         }
-      } else {
-        ProgressView()
+        NavigationStack {
+          SettingsPage()
+        }
+        .tabItem {
+          Label("Settings", systemImage: "gear")
+        }
       }
-    }
-    .task(priority: .background) {
-      do {
-        isLogReadingEnabled = try checkIfLogReadingIsEnabled()
-      } catch {
-        isLogReadingEnabled = false
+      .task(priority: .background) {
+        do {
+          isLogReadingEnabled = try checkIfLogReadingIsEnabled()
+        } catch {
+          isLogReadingEnabled = false
+        }
       }
+    } else {
+      ProgressView()
     }
   }
 

--- a/ElectricSidecar/UI/GarageView.swift
+++ b/ElectricSidecar/UI/GarageView.swift
@@ -8,17 +8,9 @@ extension URLCache {
 
 struct GarageView: View {
   @StateObject var store: ModelStore
-  let authFailure: (Error) -> Void
-
-  enum LoadState {
-    case error(error: Error)
-    case loadingVehicles
-    case loaded
-  }
 
   @State var isLogReadingEnabled: Bool = false
 
-  @State var loadState: LoadState = .loadingVehicles
   var body: some View {
     NavigationStack {
       if let vehicles = store.vehicles {

--- a/ElectricSidecar/UI/Settings/Pages/ChargeSettingsPage.swift
+++ b/ElectricSidecar/UI/Settings/Pages/ChargeSettingsPage.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SwiftUI
+import WidgetKit
+
+struct ChargeSettingsPage: View {
+  @AppStorage("preferences", store: UserDefaults(suiteName: APP_GROUP_IDENTIFIER))
+  var preferences = Preferences()
+
+  @State var batteryLevel: Double = 50
+  @State var isCharging: Bool = true
+  var body: some View {
+    List {
+      Section {
+        HStack {
+#if !os(watchOS)
+          Text("Layout")
+          Spacer(minLength: 24)
+#endif
+          Picker("Layout", selection: $preferences.chargeWidget.circularLayout) {
+            ForEach(ChargeWidgetPreferences.CircularLayout.allCases, id: \.self) { item in
+              switch item {
+              case .chargeStateInCenter:
+                Text("Charge state")
+              case .percentInCenter:
+                Text("Percent")
+              }
+            }
+          }
+          .onChange(of: preferences.chargeWidget.circularLayout) { tag in
+            reloadAllTimelines()
+          }
+#if !os(watchOS)
+          .pickerStyle(.segmented)
+#endif
+        }
+      } header: {
+        VStack(alignment: .leading) {
+          HStack {
+            Spacer()
+            ChargeView(
+              batteryLevel: batteryLevel,
+              isCharging: isCharging,
+              layout: preferences.chargeWidget.circularLayout
+            )
+            .frame(width: circularComplicationSize().width,
+                   height: circularComplicationSize().height)
+            .cornerRadius(circularComplicationSize().width / 2)
+            Spacer()
+          }
+          Text("Options")
+        }
+      }
+
+      Section("Simulator") {
+        HStack {
+#if os(watchOS)
+          Image(systemName: "bolt")
+            .foregroundColor(.primary)
+#else
+          Text("Charge")
+            .foregroundColor(.primary)
+          Spacer(minLength: 24)
+#endif
+          Slider(value: $batteryLevel, in: 0...100) {
+            Text("Charge")
+          } minimumValueLabel: {
+            Text("0")
+              .foregroundColor(.secondary)
+          } maximumValueLabel: {
+            Text("100")
+              .foregroundColor(.secondary)
+          }
+        }
+        HStack {
+          Toggle("Is charging", isOn: $isCharging)
+            .foregroundColor(.primary)
+        }
+      }
+    }
+    .navigationTitle("Charge widget")
+  }
+}
+
+struct ChargeSettingsPage_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationStack {
+      ChargeSettingsPage()
+    }
+  }
+}

--- a/ElectricSidecar/UI/Settings/SettingsPage.swift
+++ b/ElectricSidecar/UI/Settings/SettingsPage.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftUI
+
+struct SettingsPage: View {
+  @AppStorage("preferences", store: UserDefaults(suiteName: APP_GROUP_IDENTIFIER))
+  var preferences = Preferences()
+
+  var body: some View {
+    List {
+      Section("Widgets") {
+        NavigationLink("Charge") {
+          ChargeSettingsPage()
+        }
+      }
+    }
+    .navigationTitle("Settings")
+  }
+}
+
+struct SettingsPage_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationStack {
+      SettingsPage()
+    }
+  }
+}

--- a/ElectricSidecar/UI/Vehicle/VehicleView.swift
+++ b/ElectricSidecar/UI/Vehicle/VehicleView.swift
@@ -16,6 +16,9 @@ struct VehicleView: View {
   let vehicle: UIModel.Vehicle
   let hasManyVehicles: Bool
 
+  @AppStorage("preferences", store: UserDefaults(suiteName: APP_GROUP_IDENTIFIER))
+  var preferences = Preferences()
+
   let statusPublisher: AnyPublisher<UIModel.Refreshable<UIModel.Vehicle.Status>, Never>
   let emobilityPublisher: AnyPublisher<UIModel.Refreshable<UIModel.Vehicle.Emobility>, Never>
   let positionPublisher: AnyPublisher<UIModel.Refreshable<UIModel.Vehicle.Position>, Never>
@@ -76,6 +79,7 @@ struct VehicleView: View {
                 ChargeView(
                   batteryLevel: status?.batteryLevel,
                   isCharging: emobility?.isCharging,
+                  layout: preferences.chargeWidget.circularLayout,
                   allowsAnimation: true
                 )
                 .frame(width: circularComplicationSize().width,
@@ -121,11 +125,7 @@ struct VehicleView: View {
             set: {
               if $0 {
                 AUTH_MODEL.preferences.primaryVIN = vehicle.vin
-                UserDefaults(suiteName: APP_GROUP_IDENTIFIER)!.synchronize()
-
-                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-                  WidgetCenter.shared.reloadAllTimelines()
-                }
+                reloadAllTimelines()
               }
             }
           ))
@@ -295,7 +295,7 @@ struct VehicleView: View {
               isRefreshing = false
             }
             Logging.network.info("Refreshing all widget timelines")
-            WidgetCenter.shared.reloadAllTimelines()
+            reloadAllTimelines()
           }
         }
       }

--- a/ElectricSidecar/Watch/ElectricSidecarApp.swift
+++ b/ElectricSidecar/Watch/ElectricSidecarApp.swift
@@ -29,14 +29,19 @@ struct ElectricSidecar: App {
               return
             }
             Task {
-              try await store.load()
+              do {
+                try await store.load()
+              } catch {
+                DispatchQueue.main.async {
+                  AUTH_MODEL.authenticationFailed()
+                  authState = .loggedOut(error: error)
+                }
+              }
             }
             authState = .authenticated(store: store)
           }
       case .authenticated(let store):
-        GarageView(store: store) { error in
-          authState = .loggedOut(error: error)
-        }
+        GarageView(store: store)
       case .loggedOut(let error):
         ScrollView {
           VStack {

--- a/ElectricSidecar/Widgets/VehicleCharge/VehicleChargeWidget.swift
+++ b/ElectricSidecar/Widgets/VehicleCharge/VehicleChargeWidget.swift
@@ -32,6 +32,9 @@ private struct WidgetView : View {
   @Environment(\.widgetFamily) var family
   @Environment(\.widgetRenderingMode) var widgetRenderingMode
 
+  @AppStorage("preferences", store: UserDefaults(suiteName: APP_GROUP_IDENTIFIER))
+  var preferences = Preferences()
+
   let entry: VehicleChargeTimelineProvider.Entry
 
   var body: some View {
@@ -40,7 +43,8 @@ private struct WidgetView : View {
     case .accessoryCircular:
       ChargeView(
         batteryLevel: entry.chargeRemaining,
-        isCharging: entry.isCharging == true
+        isCharging: entry.isCharging == true,
+        layout: preferences.chargeWidget.circularLayout
       )
 
     case .accessoryInline:


### PR DESCRIPTION
New features / bug fixes include:

- Authentication errors are now made visible during login so that you don't get stuck on the spinner screen.
- The charge widget can now be customized between two different layouts: charge state in the center, or charge percent in the center.
- More tuning of the charge state complication's layout. Specifically, the font size now always matches the font size of the range complication so that they appear visually consistent when shown on-screen together.

Video of the new charge widget configuration page:

| Phone | Watch |
|:-------|:-------|
| ![](https://user-images.githubusercontent.com/45670/223233249-805cc634-2f3e-4f0d-b19a-0c52fac95163.mov) | ![](https://user-images.githubusercontent.com/45670/223233228-cf8cfada-044a-4354-893d-5a225d3e383d.mp4) |









